### PR TITLE
Sert documentation of tol to what it actually is by default.

### DIFF
--- a/R/nipals.R
+++ b/R/nipals.R
@@ -42,7 +42,7 @@ if(FALSE){
 #' @param maxiter Maximum number of NIPALS iterations for each
 #' principal component.
 #'
-#' @param tol Default 1e-9 tolerance for testing convergence of the NIPALS
+#' @param tol Default 1e-6 tolerance for testing convergence of the NIPALS
 #' iterations for each principal component.
 #'
 #' @param startcol Determine the starting column of x for the iterations


### PR DESCRIPTION
Seems the tolerance was documented to be tol = 1e-09 by default but the code says tol = 1e-06.